### PR TITLE
CRX Package Manager Upload: Switch default URL for system ready check to /systemready.json

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.4.2" date="not released">
+      <action type="update" dev="sseifert">
+        CRX Package Manager Upload: Switch default URL for system ready check to /systemready.json
+      </action>
+    </release>
+
     <release version="2.4.0" date="2025-09-25">
       <action type="update" dev="sseifert">
         Switch to Java 17.

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="2.4.2" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="41">
         CRX Package Manager Upload: Switch default URL for system ready check to /systemready.json
       </action>
     </release>

--- a/src/main/java/io/wcm/maven/plugins/contentpackage/AbstractContentPackageMojo.java
+++ b/src/main/java/io/wcm/maven/plugins/contentpackage/AbstractContentPackageMojo.java
@@ -201,7 +201,7 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
    * after installing finishing the upload. This works only for AEMaaCS SDK instances.
    *
    * <p>
-   * Expected is an URL like: http://localhost:4502/systemready
+   * Expected is an URL like: http://localhost:4502/systemready.json
    * </p>
    *
    * <p>
@@ -332,7 +332,7 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
     }
     // if not set use hostname from serviceURL and add default path to bundle status
     String baseUrl = VendorInstallerFactory.getBaseUrl(buildPackageManagerUrl());
-    return baseUrl + "/systemready";
+    return baseUrl + "/systemready.json";
   }
 
   private String buildPackageManagerInstallStatusUrl() throws MojoExecutionException {


### PR DESCRIPTION
Fixes https://github.com/wcm-io/io.wcm.maven.plugins.wcmio-content-package-maven-plugin/issues/40